### PR TITLE
Update story and zoom extents, drop bbox limits

### DIFF
--- a/src/assets/mapStory/mapStory.js
+++ b/src/assets/mapStory/mapStory.js
@@ -5,7 +5,7 @@ export default {
             "class": "active",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-97, 24],
+                "center": [-98, 39],
                 "zoom": 3,
                 "pitch": 0,
                 "speed": 0.2,
@@ -39,7 +39,7 @@ export default {
             "class": "",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-97, 24],
+                "center": [-98, 39],
                 "zoom": 3,
                 "pitch": 0,
                 "speed": 0.2,
@@ -56,7 +56,7 @@ export default {
             "class": "",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-97, 24],
+                "center": [-98, 39],
                 "zoom": 3,
                 "pitch": 0,
                 "speed": 0.2,
@@ -73,8 +73,8 @@ export default {
             "class": "",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-97, 24],
-                "zoom": 3,
+                "center": [-128, 46],
+                "zoom": 2,
                 "pitch": 0,
                 "speed": 0.2,
                 "curve": 1,
@@ -90,7 +90,7 @@ export default {
             "class": "",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-97, 24],
+                "center": [-98, 39],
                 "zoom": 3,
                 "pitch": 0,
                 "speed": 0.2,
@@ -107,8 +107,8 @@ export default {
             "class": "",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-97, 24],
-                "zoom": 3,
+                "center": [-128, 46],
+                "zoom": 2,
                 "pitch": 0,
                 "speed": 0.2,
                 "curve": 1,
@@ -124,8 +124,8 @@ export default {
             "class": "",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-97, 24],
-                "zoom": 3,
+                "center": [-128, 46],
+                "zoom": 2,
                 "pitch": 0,
                 "speed": 0.2,
                 "essential": true
@@ -140,8 +140,8 @@ export default {
             "class": "",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-111, 30],
-                "zoom": 5,
+                "center": [-111, 34],
+                "zoom": 4,
                 "pitch": 0,
                 "speed": 0.2,
                 "essential": true
@@ -156,7 +156,7 @@ export default {
             "class": "",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-128, 34],
+                "center": [-128, 46],
                 "zoom": 2,
                 "pitch": 0,
                 "speed": 0.2,
@@ -172,8 +172,8 @@ export default {
             "class": "",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-82, 31],
-                "zoom": 4,
+                "center": [-82, 45],
+                "zoom": 3,
                 "pitch": 0,
                 "speed": 0.2,
                 "essential": true
@@ -188,7 +188,7 @@ export default {
             "class": "",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-84, 34],
+                "center": [-84, 39],
                 "zoom": 5,
                 "pitch": 0,
                 "speed": 0.5,
@@ -204,8 +204,8 @@ export default {
             "class": "",
             "flyToCommands": {
                 "bearing": 0,
-                "center": [-97, 24],
-                "zoom": 3,
+                "center": [-128, 46],
+                "zoom": 2,
                 "pitch": 0,
                 "speed": 0.2,
                 "essential": true

--- a/src/components/MapBox.vue
+++ b/src/components/MapBox.vue
@@ -114,7 +114,7 @@
                 center: [-95.7129, 37.0902],
                 pitch: 0, // tips the map from 0 to 60 degrees
                 bearing: 0, // starting rotation of the map from 0 to 360
-                maxBounds: [[-168.534393,-4.371744], [-19.832382,71.687625]], // The coordinates needed to make a bounding box for the continental United States.
+                //maxBounds: [[-168.534393,-4.371744], [-19.832382,71.687625]], // The coordinates needed to make a bounding box for the continental United States.
                 isLoading: true
             };
         },


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
After Marty fixed up the viewport/scrolling issues, I was able to better refine the center points 
also removed the mapbounds limits because it was cutting out alaska

Description
-----------
After Marty fixed up the viewport/scrolling issues, I was able to better refine the center points 
also removed the mapbounds limits because it was cutting out alaska

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial